### PR TITLE
update scroll position before rerendering

### DIFF
--- a/src/ScrollManager.js
+++ b/src/ScrollManager.js
@@ -32,9 +32,9 @@ class ScrollManager extends React.Component {
     this.scrollBehavior.updateScroll(null, renderArgs);
   }
 
-  componentDidUpdate(prevProps) {
-    const { renderArgs } = this.props;
-    const prevRenderArgs = prevProps.renderArgs;
+  componentWillUpdate(nextProps) {
+    const { renderArgs } = nextProps;
+    const prevRenderArgs = this.props.renderArgs;
 
     if (renderArgs.location === prevRenderArgs.location) {
       return;


### PR DESCRIPTION
Updating the scroll position in componentDidUpdate will only scroll the page after the page already completely rerendered. This is equivalent to the browser updating the scroll position after downloading and completely rendering the newly navigated page.
changing to componentWillUpdate better emulates the native browser scrolling where it scrolls after the new page was loaded but before it renders the next page.