### PR TITLE
fix: types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,4 +47,4 @@ export interface ScrollManagerProps {
   children?: React.ReactNode;
 }
 
-export default class ScrollManager extends Component<ScrollManagerProps> {}
+export class ScrollManager extends Component<ScrollManagerProps> {}


### PR DESCRIPTION
not actually a default export

https://github.com/4Catalyzer/found-scroll/blob/master/src/index.js