### PR TITLE
Move 4Catalyzer CLI to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "homepage": "https://github.com/4Catalyzer/found-scroll#readme",
   "dependencies": {
-    "@4c/cli": "^2.1.11",
     "farce": "^0.4.5",
     "prop-types": "^15.7.2",
     "scroll-behavior": "^0.11.0"
@@ -61,6 +60,7 @@
   },
   "devDependencies": {
     "@4c/babel-preset": "^8.0.2",
+    "@4c/cli": "^2.1.11",
     "@4c/tsconfig": "^0.3.1",
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
Hi,

@4c/cli is listed in the project's dependencies, but it isn't used anywhere in the source code. Looks like it could be moved to the devDependencies.

Thanks.